### PR TITLE
Build static recipe site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Build site
+        run: python build.py
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+site/
+node_modules/
+static/search.js
+

--- a/build.py
+++ b/build.py
@@ -1,0 +1,147 @@
+import os
+import re
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+RECIPES_DIR = Path('recipes')
+OUTPUT_DIR = Path('site')
+
+RECIPE_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>{title}</title>
+  <link rel='stylesheet' href='../styles.css'>
+</head>
+<body>
+  <a href='../index.html'>Home</a>
+  <h1>{title}</h1>
+  {body}
+  <p><a href='{download}' download>Download recipe</a></p>
+</body>
+</html>
+"""
+
+INDEX_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>Recipes</title>
+  <link rel='stylesheet' href='styles.css'>
+</head>
+<body>
+  <h1>Recipes</h1>
+  <input id='search' placeholder='Search recipes'>
+  <select id='tag'><option value=''>All Tags</option></select>
+  <ul id='results'></ul>
+  <script>const TAGS = {tags};</script>
+  <script src='search.js'></script>
+</body>
+</html>
+"""
+
+
+def slugify(name: str) -> str:
+    name = name.lower().strip()
+    name = re.sub(r'[^a-z0-9\s-]', '', name)
+    name = re.sub(r'[\s]+', '-', name)
+    return name
+
+
+def markdown_to_html(text: str) -> str:
+    lines = text.splitlines()
+    html_lines = []
+    in_list = False
+    for line in lines:
+        if line.startswith('- '):
+            if not in_list:
+                html_lines.append('<ul>')
+                in_list = True
+            html_lines.append(f"<li>{line[2:].strip()}</li>")
+        else:
+            if in_list:
+                html_lines.append('</ul>')
+                in_list = False
+            if line.startswith('>'):
+                html_lines.append(f"<blockquote>{line[1:].strip()}</blockquote>")
+            elif line.startswith('![](') and line.endswith(')'):
+                src = line[4:-1]
+                html_lines.append(f"<img src='{src}' alt='' />")
+            elif line.startswith('# '):
+                html_lines.append(f"<h1>{line[2:].strip()}</h1>")
+            elif line.strip() == '':
+                continue
+            else:
+                html_lines.append(f"<p>{line}</p>")
+    if in_list:
+        html_lines.append('</ul>')
+    return "\n".join(html_lines)
+
+
+def parse_recipe(path: Path, package: bool):
+    text = path.read_text(encoding='utf-8')
+    title_match = re.search(r'^#\s+(.+)', text, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else path.stem
+    desc_match = re.search(r'^>\s+(.+)', text, re.MULTILINE)
+    tags = re.findall(r'#(\w+)', desc_match.group(1)) if desc_match else []
+    if package:
+        text = re.sub(r'!\[]\(([^)]+\.webp)\)', r'![](Photos/\1)', text)
+    html_body = markdown_to_html(text)
+    plain = re.sub(r'<[^>]+>', '', html_body)
+    return title, tags, html_body, plain
+
+
+def build():
+    subprocess.run(["npm", "run", "build"], check=True)
+    if OUTPUT_DIR.exists():
+        shutil.rmtree(OUTPUT_DIR)
+    OUTPUT_DIR.mkdir()
+
+    recipes_meta = []
+    for item in RECIPES_DIR.iterdir():
+        if item.suffix == '.recipe':
+            recipe_path = item
+            package = False
+        elif item.suffix == '.recipepackage':
+            recipe_path = item / f'{item.stem}.recipe'
+            package = True
+        else:
+            continue
+
+        slug = slugify(item.stem)
+        out_dir = OUTPUT_DIR / slug
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        title, tags, html_body, plain_text = parse_recipe(recipe_path, package)
+
+        shutil.copy2(recipe_path, out_dir / f'{slug}.recipe')
+        if package:
+            photos_src = item / 'Photos'
+            if photos_src.exists():
+                shutil.copytree(photos_src, out_dir / 'Photos')
+
+        html = RECIPE_TEMPLATE.format(title=title, body=html_body, download=f'{slug}.recipe')
+        (out_dir / 'index.html').write_text(html, encoding='utf-8')
+
+        recipes_meta.append({
+            'title': title,
+            'url': f'{slug}/',
+            'tags': tags,
+            'content': plain_text
+        })
+
+    tags_set = sorted({t for r in recipes_meta for t in r['tags']})
+    index_html = INDEX_TEMPLATE.format(tags=json.dumps(tags_set))
+    (OUTPUT_DIR / 'index.html').write_text(index_html, encoding='utf-8')
+    (OUTPUT_DIR / 'recipes.json').write_text(json.dumps(recipes_meta), encoding='utf-8')
+
+    static_dir = Path('static')
+    for file in ['styles.css', 'search.js']:
+        shutil.copy2(static_dir / file, OUTPUT_DIR / file)
+
+
+if __name__ == '__main__':
+    build()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "recipes",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}
+

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,51 @@
+interface Recipe {
+  title: string;
+  url: string;
+  tags: string[];
+  content: string;
+}
+
+declare const TAGS: string[];
+
+async function init(): Promise<void> {
+  const resp = await fetch('recipes.json');
+  const recipes: Recipe[] = await resp.json();
+  const searchInput = document.getElementById('search') as HTMLInputElement;
+  const tagSelect = document.getElementById('tag') as HTMLSelectElement;
+  const resultsList = document.getElementById('results') as HTMLUListElement;
+
+  TAGS.forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    tagSelect.appendChild(opt);
+  });
+
+  function render(list: Recipe[]): void {
+    resultsList.innerHTML = '';
+    list.forEach(r => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = r.url;
+      a.textContent = r.title;
+      li.appendChild(a);
+      resultsList.appendChild(li);
+    });
+  }
+
+  function filter(): void {
+    const q = searchInput.value.toLowerCase();
+    const tag = tagSelect.value;
+    const filtered = recipes.filter(r =>
+      (!tag || r.tags.includes(tag)) &&
+      (r.title.toLowerCase().includes(q) || r.content.toLowerCase().includes(q))
+    );
+    render(filtered);
+  }
+
+  searchInput.addEventListener('input', filter);
+  tagSelect.addEventListener('change', filter);
+  render(recipes);
+}
+
+init();

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,6 @@
+body { font-family: sans-serif; margin: 2rem; }
+a { color: #0645ad; }
+input, select { margin: 0.5rem 0; padding: 0.4rem; }
+ul { list-style: none; padding: 0; }
+li { margin: 0.3rem 0; }
+img { max-width: 100%; height: auto; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "lib": ["ES2017", "DOM"],
+    "strict": true
+  },
+  "include": ["src/search.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    outDir: 'static',
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, 'src/search.ts'),
+      formats: ['iife'],
+      fileName: () => 'search.js'
+    }
+  }
+});
+


### PR DESCRIPTION
## Summary
- bundle TypeScript search module with Vite and invoke it from the Python build
- add Node setup to the Pages workflow and ignore generated artifacts
- configure Vite and TypeScript for ESNext modules

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm run build` (fails: vite: not found)
- `python build.py` (fails: Command ['npm', 'run', 'build'] returned non-zero exit status 127)


------
https://chatgpt.com/codex/tasks/task_b_68b2fdf72b2c83259147787d59d111b7