### PR TITLE
Update Pages workflow to use latest artifact action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build site
         run: python build.py
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: site
 


### PR DESCRIPTION
## Summary
- use `actions/upload-pages-artifact@v3` in pages deploy workflow to avoid deprecated `upload-artifact@v3`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Option "build.lib.name" is required)


------
https://chatgpt.com/codex/tasks/task_b_68b3034447b08325a3c7a74bdd8d3b0f