### PR TITLE
chore: update deploy workflow for vite build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
+      - run: npm ci
       - name: Build site
         run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: static
+          path: dist
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- update Pages workflow to install dependencies with `npm ci`
- publish Vite's `dist` output in Pages deployment

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b311beb068832587e29c48d96675a6