### PR TITLE
Fix GitHub Pages asset paths

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename="/Recipes">
       <App />
     </BrowserRouter>
   </React.StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/Recipes/',
   plugins: [react()]
 });


### PR DESCRIPTION
## Summary
- configure Vite to serve from /Recipes on GitHub Pages
- add router basename for the /Recipes subdirectory

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b327ea29f48325a4542768a8dc5f8c