### PR TITLE
feat: add 404.html for GitHub Pages SPA support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "prebuild": "node scripts/build-data.mjs",
-    "build": "vite build"
+    "build": "vite build",
+    "postbuild": "cp dist/index.html dist/404.html"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
Closes #14

This PR adds a post-build step to copy `dist/index.html` to `dist/404.html` to properly handle direct navigation to subroutes in the SPA when hosted on GitHub Pages.

When users navigate directly to a subroute (e.g., `/recipe/some-recipe`), GitHub Pages returns a 404. By providing a 404.html that's a copy of index.html, the SPA can handle the routing client-side.

## Changes
- Added `postbuild` script in package.json to copy index.html to 404.html after build

## Test Plan
- Ran `npm run build` locally and verified 404.html is created in dist/
- Both index.html and 404.html have identical content