### PR TITLE
feat: Fix image rendering for recipe packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "node scripts/build-data.mjs",
     "build": "vite build",
-    "postbuild": "cp dist/index.html dist/404.html"
+    "postbuild": "cp dist/index.html dist/404.html && node scripts/copy-images.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/copy-images.mjs
+++ b/scripts/copy-images.mjs
@@ -1,0 +1,29 @@
+import { readdir, cp } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+async function copyRecipeImages() {
+  const recipesDir = join(process.cwd(), 'recipes');
+  const distDir = join(process.cwd(), 'dist', 'recipes');
+  
+  // Get all entries in recipes directory
+  const entries = await readdir(recipesDir, { withFileTypes: true });
+  
+  // Find all .recipepackage directories
+  for (const entry of entries) {
+    if (entry.isDirectory() && entry.name.endsWith('.recipepackage')) {
+      const photosDir = join(recipesDir, entry.name, 'Photos');
+      
+      // Check if Photos directory exists
+      if (existsSync(photosDir)) {
+        const targetDir = join(distDir, entry.name, 'Photos');
+        
+        // Copy the Photos directory to dist
+        await cp(photosDir, targetDir, { recursive: true });
+        console.log(`Copied images from ${entry.name}/Photos to dist`);
+      }
+    }
+  }
+}
+
+copyRecipeImages().catch(console.error);


### PR DESCRIPTION
Closes #20

## Changes
- Created a new script `scripts/copy-images.mjs` that copies Photos directories from .recipepackage folders to the dist folder during the build process
- Updated the `postbuild` script in package.json to run the image copy script after building
- This ensures recipe images are available at the expected paths while keeping them out of the public folder as required

## Testing
- Ran `npm run build` successfully 
- Verified that Photos directories are copied to dist/recipes/[name].recipepackage/Photos/
- Images should now render correctly when viewing recipes with photos