### PR TITLE
feat: Fix image folder paths for recipepackages

### DIFF
--- a/scripts/build-data.mjs
+++ b/scripts/build-data.mjs
@@ -1,5 +1,5 @@
 import { readdir, readFile, writeFile } from 'fs/promises';
-import { join, extname, basename } from 'path';
+import { join, extname, basename, dirname } from 'path';
 
 async function getRecipeFiles(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -43,7 +43,16 @@ async function build() {
     const tags = extractTags(content);
     tags.forEach(t => allTags.add(t));
     const slug = slugify(title);
-    recipes.push({ title, slug, tags, content });
+    
+    // Check if this is a recipepackage
+    const parentDir = basename(dirname(file));
+    const packageFolder = parentDir.endsWith('.recipepackage') ? parentDir : null;
+    
+    const recipe = { title, slug, tags, content };
+    if (packageFolder) {
+      recipe.packageFolder = packageFolder;
+    }
+    recipes.push(recipe);
   }
 
   await writeFile(join('public', 'recipes.json'), JSON.stringify(recipes, null, 2));

--- a/src/pages/RecipePage.tsx
+++ b/src/pages/RecipePage.tsx
@@ -8,6 +8,7 @@ interface Recipe {
   slug: string;
   tags: string[];
   content: string;
+  packageFolder?: string;
 }
 
 export default function RecipePage() {
@@ -31,8 +32,9 @@ export default function RecipePage() {
   const processedContent = recipe.content.replace(
     /!\[([^\]]*)\]\(([-\w]+\.(webp|jpeg|jpg|png|gif))\)/gi,
     (match, alt, filename) => {
-      // Check if this is a recipepackage by looking for Photos/ directory
-      const packageBase = `${import.meta.env.BASE_URL}recipes/${slug}.recipepackage/Photos/`;
+      // Use the actual package folder name if available, otherwise fall back to slug
+      const folderName = recipe.packageFolder || `${slug}.recipepackage`;
+      const packageBase = `${import.meta.env.BASE_URL}recipes/${folderName}/Photos/`;
       return `![${alt}](${packageBase}${filename})`;
     }
   );


### PR DESCRIPTION
Closes #22

## Changes
This PR fixes the issue where images in recipepackages were not loading due to incorrect folder paths. The URLs were using slugified names (e.g., `beef-stroganoff.recipepackage`) while the actual directories have proper names with spaces (e.g., `Beef Stroganoff.recipepackage`).

### Implementation
1. **Modified `scripts/build-data.mjs`**: Now detects and stores the original recipepackage folder name in the recipe JSON data
2. **Updated `RecipePage.tsx`**: Uses the actual folder name when constructing image URLs instead of the slugified version

### Testing
- Ran `npm run build` to verify the build process completes successfully
- Verified that `recipes.json` now includes `packageFolder` property for recipepackages
- Confirmed images are correctly copied to dist with proper folder structure
- Image URLs now correctly resolve to the actual folder names