### PR TITLE
feat: Fix image rendering variable reference in RecipePage

### DIFF
--- a/src/pages/RecipePage.tsx
+++ b/src/pages/RecipePage.tsx
@@ -33,7 +33,7 @@ export default function RecipePage() {
     /!\[([^\]]*)\]\(([-\w]+\.(webp|jpeg|jpg|png|gif))\)/gi,
     (match, alt, filename) => {
       // Use the actual package folder name if available, otherwise fall back to slug
-      const folderName = recipe.packageFolder || `${slug}.recipepackage`;
+      const folderName = recipe.packageFolder || `${recipe.slug}.recipepackage`;
       const packageBase = `${import.meta.env.BASE_URL}recipes/${folderName}/Photos/`;
       return `![${alt}](${packageBase}${filename})`;
     }


### PR DESCRIPTION
Closes #24

## Changes
Fixed the image URL construction in RecipePage.tsx by using the correct variable reference. The code was using `slug` instead of `recipe.slug` when building the fallback folder name for recipe packages.

## Details
- Changed line 36 in src/pages/RecipePage.tsx
- The fallback folder name now correctly uses `recipe.slug` to construct the path
- This ensures images in recipepackage folders render correctly

## Testing
- Build completed successfully with `npm run build`
- All recipe package images are now correctly referenced